### PR TITLE
In f90 wrappers, mark global cw as threadprivate

### DIFF
--- a/src/snopt_wrapper.f90
+++ b/src/snopt_wrapper.f90
@@ -206,6 +206,7 @@ module snopt_wrapper
   ! Character arrays don't work well with Fortran/C/C++ so have a dummy one here.
   integer, parameter :: lencw = 500
   character*8        :: cw(lencw)
+  !$OMP THREADPRIVATE(cw)
 
 contains
 

--- a/src/sqopt_wrapper.f90
+++ b/src/sqopt_wrapper.f90
@@ -63,6 +63,7 @@ module sqopt_wrapper
   ! Character arrays don't work well with Fortran/C/C++ so have a dummy one here.
   integer, parameter :: lencw = 500
   character*8        :: cw(lencw)
+  !$OMP THREADPRIVATE(cw)
 
 contains
 


### PR DESCRIPTION
Otherwise, solving distinct problems in multiple threads has data races.
